### PR TITLE
feat: override table and model name

### DIFF
--- a/src/core/cli/routes.js
+++ b/src/core/cli/routes.js
@@ -2,6 +2,43 @@
 
 const CoreConfig = require("../config");
 const fs = require("fs");
+const pluralize = require("pluralize");
+
+function getNameForms(name) {
+  const singular = pluralize.singular(name);
+  const plural = pluralize.plural(name);
+
+  // todo: should only need to make this pass 1 time
+  const resourceSingular = singular.split("").reduce((acc, curr, idx) => {
+    if (curr === curr.toUpperCase() && idx !== 0) {
+      acc += `_${curr.toLowerCase()}`;
+    } else if (idx === 0) {
+      acc += curr.toLowerCase();
+    } else {
+      acc += curr;
+    }
+
+    return acc;
+  }, "");
+  const resourcePlural = plural.split("").reduce((acc, curr, idx) => {
+    if (curr === curr.toUpperCase() && idx !== 0) {
+      acc += `_${curr.toLowerCase()}`;
+    } else if (idx === 0) {
+      acc += curr.toLowerCase();
+    } else {
+      acc += curr;
+    }
+
+    return acc;
+  }, "");
+
+  return {
+    singular,
+    plural,
+    resourceSingular,
+    resourcePlural
+  };
+}
 
 module.exports = function() {
   const dir = process.cwd();
@@ -25,7 +62,8 @@ module.exports = function() {
 
   for (let i = 0; i < controllers.length; i++) {
     const Controller = require(`${dir}/app/controllers/${controllers[i]}`);
-    const controllerName = Controller.name.split("Controller")[0].toLowerCase();
+    const controllerName = getNameForms(Controller.name.split("Controller")[0])
+      .resourcePlural;
     const actions = Object.getOwnPropertyNames(Controller)
       .filter(p => CoreConfig.actionNames.indexOf(p) !== -1)
       .sort((a, b) => a[0].localeCompare(b[0]));

--- a/src/core/model/base.js
+++ b/src/core/model/base.js
@@ -44,29 +44,23 @@ module.exports = class ActiveRecord {
     Object.keys(attrs).forEach(k => {
       self[k] = attrs[k];
     });
-
-    // todo: precalculate the columns and cases
   }
 
-  get modelName() {
-    return getNameForms(this.constructor.name).singular;
+  static get modelName() {
+    return getNameForms(this.name).singular;
   }
 
-  get tableName() {
-    return getNameForms(this.constructor.name).resourcePlural;
+  static get tableName() {
+    return getNameForms(this.name).resourcePlural;
   }
 
   static async all() {
-    const modelName = getNameForms(this.name).singular;
-    const Model = require(`${process.cwd()}/app/models/${modelName}`);
-    const table = `${getNameForms(this.name).resourcePlural}`;
-
     try {
+      const Model = require(`${process.cwd()}/app/models/${this.modelName}`);
       const columns = await db
         .connection()
-        .table(table)
+        .table(this.tableName)
         .columnInfo();
-
       const cases = Object.keys(columns).map(k => {
         return {
           snake: k,
@@ -78,11 +72,10 @@ module.exports = class ActiveRecord {
             .join("")
         };
       });
-
       const rows = await db
         .connection()
         .select()
-        .from(table)
+        .from(this.tableName)
         .orderBy("created_at", "asc")
         .catch(err => {
           console.error(`Error caught: ${err.message}`);
@@ -106,50 +99,47 @@ module.exports = class ActiveRecord {
 
       return models;
     } catch (ex) {
-      console.error(`Exception in ${name}.all :: ${ex.message}`);
+      console.error(`Exception in ${this.modelName}.all :: ${ex.message}`);
       return null;
     }
   }
 
   static async create(attrs) {
-    const modelName = getNameForms(this.name).singular;
-    const Model = require(`${process.cwd()}/app/models/${modelName}`);
-    const table = `${getNameForms(this.name).resourcePlural}`;
-
-    const columns = await db
-      .connection()
-      .table(table)
-      .columnInfo();
-
-    const cases = Object.keys(columns).map(k => {
-      return {
-        snake: k,
-        camel: k
-          .split("_")
-          .map((v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v))
-          .join("")
-      };
-    });
-
-    const toCreate = Object.keys(attrs).reduce((acc, curr) => {
-      const validColumn = cases.filter(c => c.camel === curr);
-
-      if (validColumn.length) {
-        acc[validColumn[0].snake] = attrs[curr];
-      }
-
-      return acc;
-    }, {});
-
     try {
+      const Model = require(`${process.cwd()}/app/models/${this.modelName}`);
+      const columns = await db
+        .connection()
+        .table(this.tableName)
+        .columnInfo();
+      const cases = Object.keys(columns).map(k => {
+        return {
+          snake: k,
+          camel: k
+            .split("_")
+            .map(
+              (v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v)
+            )
+            .join("")
+        };
+      });
+      const toCreate = Object.keys(attrs).reduce((acc, curr) => {
+        const validColumn = cases.filter(c => c.camel === curr);
+
+        if (validColumn.length) {
+          acc[validColumn[0].snake] = attrs[curr];
+        }
+
+        return acc;
+      }, {});
+
       await db
         .connection()
         .insert(toCreate)
-        .into(table);
+        .into(this.tableName);
 
       return new Model(attrs);
     } catch (ex) {
-      console.error(`Error in ${modelName}.create :: ${ex.message}`);
+      console.error(`Error in ${this.modelName}.create :: ${ex.message}`);
       return null;
     }
   }
@@ -158,28 +148,26 @@ module.exports = class ActiveRecord {
     try {
       await db
         .connection()
-        .table(this.tableName)
+        .table(this.constructor.tableName)
         .where("id", this.id)
         .del();
 
       return true;
     } catch (ex) {
-      console.error(`Error in ${this.modelName}.destroy :: ${ex.message}`);
+      console.error(
+        `Error in ${this.constructor.modelName}.destroy :: ${ex.message}`
+      );
       return false;
     }
   }
 
   static async find(id) {
-    // todo: get column definitions and make sure id is of matching type
-    const modelName = getNameForms(this.name).singular;
-    const Model = require(`${process.cwd()}/app/models/${modelName}`);
-    const table = `${getNameForms(this.name).resourcePlural}`;
-
     try {
+      const Model = require(`${process.cwd()}/app/models/${this.modelName}`);
       const row = await db
         .connection()
         .select()
-        .from(table)
+        .from(this.tableName)
         .where("id", id)
         .first()
         .catch(err => {
@@ -213,17 +201,14 @@ module.exports = class ActiveRecord {
 
       return new Model(attrs);
     } catch (ex) {
-      console.error(`Exception in ${modelName}.find :: ${ex.message}`);
+      console.error(`Exception in ${this.modelName}.find :: ${ex.message}`);
       return null;
     }
   }
 
   static async findBy(attrs) {
-    const modelName = getNameForms(this.name).singular;
-    const Model = require(`${process.cwd()}/app/models/${modelName}`);
-    const table = `${getNameForms(this.name).resourcePlural}`;
-
     try {
+      const Model = require(`${process.cwd()}/app/models/${this.modelName}`);
       let findAttrs = {};
 
       Object.keys(attrs).forEach(a => {
@@ -243,9 +228,8 @@ module.exports = class ActiveRecord {
 
       const columns = await db
         .connection()
-        .table(table)
+        .table(this.tableName)
         .columnInfo();
-
       const cases = Object.keys(columns).map(k => {
         return {
           snake: k,
@@ -261,7 +245,7 @@ module.exports = class ActiveRecord {
       const rows = await db
         .connection()
         .select()
-        .from(table)
+        .from(this.tableName)
         .where(findAttrs)
         .catch(err => {
           console.error(`Error caught: ${err.message}`);
@@ -285,7 +269,7 @@ module.exports = class ActiveRecord {
 
       return models;
     } catch (ex) {
-      console.error(`Exception in ${modelName}.findBy :: ${ex.message}`);
+      console.error(`Exception in ${this.modelName}.findBy :: ${ex.message}`);
       return null;
     }
   }
@@ -297,36 +281,37 @@ module.exports = class ActiveRecord {
   }
 
   async save() {
-    const columns = await db
-      .connection()
-      .table(this.tableName)
-      .columnInfo();
-
-    const cases = Object.keys(columns).map(k => {
-      return {
-        snake: k,
-        camel: k
-          .split("_")
-          .map((v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v))
-          .join("")
-      };
-    });
-
-    const toSave = Object.keys(this).reduce((acc, curr) => {
-      const validColumn = cases.filter(c => c.camel === curr);
-
-      if (validColumn.length) {
-        acc[validColumn[0].snake] = this[curr];
-      }
-
-      return acc;
-    }, {});
-
     try {
+      const columns = await db
+        .connection()
+        .table(this.constructor.tableName)
+        .columnInfo();
+
+      const cases = Object.keys(columns).map(k => {
+        return {
+          snake: k,
+          camel: k
+            .split("_")
+            .map(
+              (v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v)
+            )
+            .join("")
+        };
+      });
+
+      const toSave = Object.keys(this).reduce((acc, curr) => {
+        const validColumn = cases.filter(c => c.camel === curr);
+
+        if (validColumn.length) {
+          acc[validColumn[0].snake] = this[curr];
+        }
+
+        return acc;
+      }, {});
       const row = await db
         .connection()
         .select()
-        .from(this.tableName)
+        .from(this.constructor.tableName)
         .where("id", this.id)
         .first()
         .catch(err => {
@@ -338,62 +323,67 @@ module.exports = class ActiveRecord {
           .connection()
           .where("id", this.id)
           .update(toSave)
-          .into(this.tableName);
+          .into(this.constructor.tableName);
       } else {
         await db
           .connection()
           .insert(toSave)
-          .into(this.tableName);
+          .into(this.constructor.tableName);
       }
 
       return true;
     } catch (ex) {
-      console.error(`Error in ${this.modelName}.save :: ${ex.message}`);
+      console.error(
+        `Error in ${this.constructor.modelName}.save :: ${ex.message}`
+      );
       return false;
     }
   }
 
   async update(args) {
-    const columns = await db
-      .connection()
-      .table(this.tableName)
-      .columnInfo();
-
-    const cases = Object.keys(columns).map(k => {
-      return {
-        snake: k,
-        camel: k
-          .split("_")
-          .map((v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v))
-          .join("")
-      };
-    });
-
-    const current = Object.keys(this).reduce((acc, curr) => {
-      if (curr === "id") {
-        return acc;
-      }
-
-      const validColumn = cases.filter(c => c.camel === curr);
-
-      if (validColumn.length) {
-        acc[validColumn[0].snake] = this[curr];
-      }
-
-      return acc;
-    }, {});
-    const toSave = Object.assign({}, current, args);
-
     try {
+      const columns = await db
+        .connection()
+        .table(this.constructor.tableName)
+        .columnInfo();
+      const cases = Object.keys(columns).map(k => {
+        return {
+          snake: k,
+          camel: k
+            .split("_")
+            .map(
+              (v, i) => (i > 0 ? `${v[0].toUpperCase()}${v.substring(1)}` : v)
+            )
+            .join("")
+        };
+      });
+
+      const current = Object.keys(this).reduce((acc, curr) => {
+        if (curr === "id") {
+          return acc;
+        }
+
+        const validColumn = cases.filter(c => c.camel === curr);
+
+        if (validColumn.length) {
+          acc[validColumn[0].snake] = this[curr];
+        }
+
+        return acc;
+      }, {});
+      const toSave = Object.assign({}, current, args);
+
       await db
         .connection()
         .where("id", this.id)
         .update(toSave)
-        .into(this.tableName);
+        .into(this.constructor.tableName);
 
       return true;
     } catch (ex) {
-      console.error(`Error in ${this.modelName}.update :: ${ex.message}`);
+      console.error(
+        `Error in ${this.constructor.modelName}.update :: ${ex.message}`
+      );
       return false;
     }
   }

--- a/src/core/router/index.js
+++ b/src/core/router/index.js
@@ -2,6 +2,53 @@
 
 const CoreConfig = require("../config");
 const fs = require("fs");
+const pluralize = require("pluralize");
+
+function getNameForms(name) {
+  const singular = pluralize.singular(name);
+  const plural = pluralize.plural(name);
+
+  // todo: should only need to make this pass 1 time
+  const resourceSingular = singular.split("").reduce((acc, curr, idx) => {
+    if (curr === curr.toUpperCase() && idx !== 0) {
+      acc += `_${curr.toLowerCase()}`;
+    } else if (idx === 0) {
+      acc += curr.toLowerCase();
+    } else {
+      acc += curr;
+    }
+
+    return acc;
+  }, "");
+  const resourcePlural = plural.split("").reduce((acc, curr, idx) => {
+    if (curr === curr.toUpperCase() && idx !== 0) {
+      acc += `_${curr.toLowerCase()}`;
+    } else if (idx === 0) {
+      acc += curr.toLowerCase();
+    } else {
+      acc += curr;
+    }
+
+    return acc;
+  }, "");
+  const nameSingular = singular
+    .split("_")
+    .map(word => word[0].toUpperCase() + word.substring(1))
+    .join("");
+  const namePlural = plural
+    .split("_")
+    .map(word => word[0].toUpperCase() + word.substring(1))
+    .join("");
+
+  return {
+    singular,
+    plural,
+    resourceSingular,
+    resourcePlural,
+    nameSingular,
+    namePlural
+  };
+}
 
 let routes = []; // private route tree
 
@@ -52,9 +99,7 @@ class Router {
 
     for (var i = 0; i < controllers.length; i++) {
       const Controller = require(`${dir}/app/controllers/${controllers[i]}`);
-      const controllerName = Controller.name
-        .split("Controller")[0]
-        .toLowerCase();
+      const controllerName = Controller.name.split("Controller")[0];
       const actions = Object.getOwnPropertyNames(Controller)
         .filter(p => CoreConfig.actionNames.indexOf(p) !== -1)
         .sort((a, b) => a[0].localeCompare(b[0]));
@@ -264,7 +309,7 @@ function routeToAction(req, res) {
    * @param {*} idx - current index of the split URL were at
    */
   function recurse(idx) {
-    const controller = urlArray[idx];
+    const controller = getNameForms(urlArray[idx]).namePlural;
 
     if (!routes[controller]) {
       return routingError(req, res);


### PR DESCRIPTION
---
name: Pull Request
about: Ask for code to be merged into master
---

**Describe your Code**
Slight refactor to allow for overriding a model's database table name. Had to fixup a router issue to be able to use the `blog_posts` naming convention in the URL

**Expected behavior**
Placing a static getter in the actual model will override the default behavior in ActiveRecord

**How to test**
Steps to test and verify the code works as expected:
1. Go through the Getting started but make migration file create table called `articles`
2. Update BlogPost to override tableName to `articles`
3. App should still work

**Screenshots**
```
exports.up = async function(knex) {
  await knex.schema.dropTableIfExists("articles");
  await knex.schema.createTable("articles", table => {
    table.uuid("id").primary();
    table.string("title");
    table.text("text");

    table.timestamps(true, true);
  });
};

exports.down = async function(knex) {
  await knex.schema.dropTableIfExists("articles");
};
```

<img width="182" alt="screen shot 2018-12-11 at 9 42 59 am" src="https://user-images.githubusercontent.com/7015773/49808042-8dd78b80-fd29-11e8-9a77-5bc19ef52ecf.png">

