### PR TITLE
feat: serve image assets

### DIFF
--- a/src/cli/server/start.js
+++ b/src/cli/server/start.js
@@ -2,6 +2,7 @@
 
 const http = require("http");
 const Router = require("../../core/router");
+const { spawnSync } = require("child_process");
 
 module.exports = function(cb) {
   const dir = process.cwd();
@@ -11,6 +12,12 @@ module.exports = function(cb) {
   const instance = http.createServer(Router.incoming);
 
   Router.load();
+
+  spawnSync(`cp -R app/assets/images/. public/assets/images`, {
+    stdio: `inherit`,
+    shell: true,
+    cwd: dir
+  });
 
   instance.listen({ port }, () => {
     console.log(

--- a/src/core/config/index.js
+++ b/src/core/config/index.js
@@ -14,6 +14,8 @@ module.exports = {
   ],
   seedDirectories: [
     "app",
+    "app/assets",
+    "app/assets/images",
     "app/controllers",
     "app/models",
     "app/views",
@@ -21,6 +23,9 @@ module.exports = {
     "config",
     "db",
     "db/migrations",
+    "public",
+    "public/assets",
+    "public/assets/images",
     "test",
     "test/controllers",
     "test/fixtures",


### PR DESCRIPTION
---
name: Pull Request
about: Ask for code to be merged into master
---

**Describe your Code**
Creates a public, assets, and image folder structure for serving background images etc

**Expected behavior**
Image files in app/assets/images are copied to public/assets/images on server start and returned via server when requested

**How to test**
Steps to test and verify the code works as expected:
1. Create new blog project
2. Add the hello world page with index action
3. add an image tag to the page referencing a background image
4. see that its not served
5. add the image to app/assets/images
6. restart server and see the image come through

**Screenshots**
<img width="1173" alt="screen shot 2019-01-02 at 10 43 42 am" src="https://user-images.githubusercontent.com/7015773/50599185-4dc47e00-0e7b-11e9-85a1-7cef19d71257.png">

