### PR TITLE
bug: account for hash and query in routes

### DIFF
--- a/src/core/helpers/UrlHelper.js
+++ b/src/core/helpers/UrlHelper.js
@@ -1,0 +1,16 @@
+const querystring = require("querystring");
+const url = require("url");
+
+module.exports = class UrlHelper {
+  static parse(requestUrl) {
+    const urlObj = url.parse(requestUrl, true);
+    const parsedHash =
+      urlObj.hash && urlObj.hash.split("#").filter(s => s.length)[0];
+
+    return {
+      hash: querystring.parse(parsedHash),
+      pathname: urlObj.pathname,
+      query: urlObj.query
+    };
+  }
+};

--- a/src/core/helpers/index.js
+++ b/src/core/helpers/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  NounHelper: require("./NounHelper")
+  NounHelper: require("./NounHelper"),
+  UrlHelper: require("./UrlHelper")
 };

--- a/test/helpers/UrlHelperTest.js
+++ b/test/helpers/UrlHelperTest.js
@@ -1,0 +1,125 @@
+const Boring = require("../../src/core");
+const UnitTest = Boring.Test.UnitTest;
+const UrlHelper = require("../../src/core/helpers").UrlHelper;
+
+module.exports = class NounHelperTest extends UnitTest {
+  constructor() {
+    super();
+  }
+
+  async "parses url without query or hash"() {
+    const parsed = UrlHelper.parse("http://localhost:3000");
+
+    this.assert(parsed.pathname).equals("/");
+
+    return true;
+  }
+
+  async "parses url with empty hash"() {
+    const parsed = UrlHelper.parse("http://localhost:3000#");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.hash).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(0);
+
+    return true;
+  }
+
+  async "parses url with single value hash"() {
+    const parsed = UrlHelper.parse("http://localhost:3000#foo=bar");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.hash).equals("object");
+    this.assert(Object.keys(parsed.hash).length).equals(1);
+    this.assert(parsed.hash["foo"]).equals("bar");
+
+    return true;
+  }
+
+  async "parses url with single value hash without ="() {
+    const parsed = UrlHelper.parse("http://localhost:3000#foo");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.hash).equals("object");
+    this.assert(Object.keys(parsed.hash).length).equals(1);
+    this.assert(parsed.hash["foo"]).equals("");
+
+    return true;
+  }
+
+  async "parses url with multiple values in hash "() {
+    const parsed = UrlHelper.parse("http://localhost:3000#foo=bar&bar=foo");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.hash).equals("object");
+    this.assert(Object.keys(parsed.hash).length).equals(2);
+    this.assert(parsed.hash["foo"]).equals("bar");
+    this.assert(parsed.hash["bar"]).equals("foo");
+
+    return true;
+  }
+
+  async "parses url with empty query"() {
+    const parsed = UrlHelper.parse("http://localhost:3000?");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.query).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(0);
+
+    return true;
+  }
+
+  async "parses url with single value query"() {
+    const parsed = UrlHelper.parse("http://localhost:3000?foo=bar");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.query).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(1);
+    this.assert(parsed.query["foo"]).equals("bar");
+
+    return true;
+  }
+
+  async "parses url with single value query without ="() {
+    const parsed = UrlHelper.parse("http://localhost:3000?foo");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.query).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(1);
+    this.assert(parsed.query["foo"]).equals("");
+
+    return true;
+  }
+
+  async "parses url with multiple values in query "() {
+    const parsed = UrlHelper.parse("http://localhost:3000?foo=bar&bar=foo");
+
+    this.assert(parsed.pathname).equals("/");
+    this.assert(typeof parsed.query).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(2);
+    this.assert(parsed.query["foo"]).equals("bar");
+    this.assert(parsed.query["bar"]).equals("foo");
+
+    return true;
+  }
+
+  async "parses url with query and hash"() {
+    const parsed = UrlHelper.parse(
+      "http://localhost:3000?foo=bar&bar=foo#foo=bar&bar=foo"
+    );
+
+    this.assert(parsed.pathname).equals("/");
+
+    this.assert(typeof parsed.query).equals("object");
+    this.assert(Object.keys(parsed.query).length).equals(2);
+    this.assert(parsed.query["foo"]).equals("bar");
+    this.assert(parsed.query["bar"]).equals("foo");
+
+    this.assert(typeof parsed.hash).equals("object");
+    this.assert(Object.keys(parsed.hash).length).equals(2);
+    this.assert(parsed.hash["foo"]).equals("bar");
+    this.assert(parsed.hash["bar"]).equals("foo");
+
+    return true;
+  }
+};


### PR DESCRIPTION
---
name: Pull Request
about: Ask for code to be merged into master
---

**Describe your Code**
Account for query string and hash in the routing. Routes broken down by pathname instead.

**Expected behavior**
Routes more sophisticated that `/**/**` are handled

