### PR TITLE
perf: cache ejs templates after loading

### DIFF
--- a/src/core/decorators/render.js
+++ b/src/core/decorators/render.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const ejs = require("ejs");
-const fs = require("fs");
+const TemplateHelper = require("../helpers/TemplateHelper");
 
 function linkTo(title, target) {
   return `<a href="${target}">${title}</a>`;
@@ -18,10 +18,7 @@ module.exports = function(dir, controller, action, data) {
       data = {};
     }
 
-    const template = fs.readFileSync(
-      `${dir}/app/views/${controller}/${action}.html.ejs`,
-      "utf8"
-    );
+    const template = TemplateHelper.load(dir, controller, action);
     const rendered = ejs.render(template, Object.assign(data, { linkTo }), {
       views: [`${dir}/app/views`]
     });

--- a/src/core/helpers/TemplateHelper.js
+++ b/src/core/helpers/TemplateHelper.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+
+let _cachedTemplates = {};
+
+module.exports = class TemplateHelper {
+  static load(directory, controller, action) {
+    if (typeof _cachedTemplates[`${controller}`][`${action}`] !== "undefined") {
+      return _cachedTemplates[`${controller}`][`${action}`];
+    }
+
+    const template = fs.readFileSync(
+      `${directory}/app/views/${controller}/${action}.html.ejs`,
+      "utf8"
+    );
+
+    _cachedTemplates[`${controller}`][`${action}`] = template;
+
+    return template;
+  }
+};


### PR DESCRIPTION
---
name: Pull Request
about: Ask for code to be merged into master
---

**Describe your Code**
Caches EJS templates after first load so we're not reading from disk on each request

**Expected behavior**
Rendering is faster on subsequent requests because the action is loaded

**Related Issues**
closes #13 
