### PR TITLE
feat: remove reload. push to clients

### DIFF
--- a/src/cli/Command/Server.js
+++ b/src/cli/Command/Server.js
@@ -7,72 +7,68 @@ const ProcessHelper = require("../../core/helpers/ProcessHelper");
 const _ = require("lodash");
 
 module.exports = class ServerCommand extends Command {
-  execute(context) {
-    const dir = ProcessHelper.cwd();
-    const projectConfig = ProcessHelper.require(`${dir}/config`);
-    const inputs = context.getInput();
-    const reload = inputs[1] && inputs[1] === "--reload";
+  execute(context /* eslint-disable-line no-unused-vars */) {
+    const { rootDirectory, projectConfig } = requireArguments(context);
+    const fastify = new Fastify({ logger: true });
+    const port = projectConfig.server.port || 3000;
+    const start = Date.now();
+    const router = new Router(projectConfig, rootDirectory);
+    const routes = router.load();
 
-    if (reload) {
-      const nodemon = ProcessHelper.require(`${dir}/node_modules/nodemon`);
-
-      nodemon({});
-
-      nodemon
-        .on("start", function() {
-          console.log("Server has started");
-        })
-        .on("quit", function() {
-          console.log("Server has quit");
-          process.exit();
-        })
-        .on("restart", function(files) {
-          console.log("Server restarted due to: ", files);
-        });
-    } else {
-      const fastify = new Fastify({ logger: true });
-      const port = projectConfig.server.port || 3000;
-      const start = Date.now();
-      const router = new Router(projectConfig, dir);
-      const routes = router.load();
-
-      if (_.get(projectConfig, "mailer.default")) {
-        spawn(`./node_modules/.bin/maildev`, {
-          stdio: `inherit`,
-          shell: true,
-          cwd: dir
-        });
-      }
-
-      routes.forEach(r => {
-        fastify.route(r);
-      });
-
-      fastify.register(require("fastify-static"), {
-        root: path.join(dir, "public")
-      });
-
-      spawnSync(`cp -R app/assets/images/. public/assets/images`, {
+    if (_.get(projectConfig, "mailer.default")) {
+      spawn(`./node_modules/.bin/maildev`, {
         stdio: `inherit`,
         shell: true,
-        cwd: dir
-      });
-
-      ProcessHelper.kill(1025);
-      ProcessHelper.kill(1080);
-
-      fastify.listen({ port }, err => {
-        if (err) {
-          fastify.log.error(`server failed to start from ${err.message}`);
-
-          return ProcessHelper.exit(1);
-        }
-
-        fastify.log.info(
-          `server listening on port ${port}. Startup took ${Date.now() -
-            start}ms`
-        );
+        cwd: rootDirectory
       });
     }
+
+    routes.forEach(r => {
+      fastify.route(r);
+    });
+
+    fastify.register(require("fastify-static"), {
+      root: path.join(rootDirectory, "public")
+    });
+
+    spawnSync(`cp -R app/assets/images/. public/assets/images`, {
+      stdio: `inherit`,
+      shell: true,
+      cwd: rootDirectory
+    });
+
+    ProcessHelper.kill(1025);
+    ProcessHelper.kill(1080);
+
+    fastify.listen({ port }, err => {
+      if (err) {
+        fastify.log.error(`server failed to start from ${err.message}`);
+
+        return ProcessHelper.exit(1);
+      }
+
+      fastify.log.info(
+        `server listening on port ${port}. Startup took ${Date.now() - start}ms`
+      );
+    });
   }
 };
+
+/**
+ * @function requireArguments
+ * @private
+ * @description check if all values provided and are valid values
+ *
+ * @param {Context} context - the context object given
+ *
+ * @throws {Error}
+ */
+function requireArguments(context /* eslint-disable-line no-unused-vars */) {
+  const rootDirectory = ProcessHelper.cwd();
+  const projectConfig = ProcessHelper.require(`${rootDirectory}/config`);
+
+  return {
+    rootDirectory,
+    projectConfig
+  };
+}

--- a/test/cli/Command/Server.test.js
+++ b/test/cli/Command/Server.test.js
@@ -80,37 +80,6 @@ test("executes server command in a separate process w/o reload option", () => {
   expect(ProcessHelper.kill).toHaveBeenCalledTimes(2);
 });
 
-test("uses nodemon to reload if --reload arg given", () => {
-  /* eslint-disable-next-line no-inner-declarations */
-  function MockNodemon() {
-    return MockNodemon;
-  }
-  MockNodemon.on = jest.fn().mockImplementation(function() {
-    return MockNodemon;
-  });
-
-  const fakeTestWorkingDirectory = "/fake/directory/that/doesnt/exist";
-
-  ProcessHelper.cwd.mockImplementation(() => fakeTestWorkingDirectory);
-  ProcessHelper.require.mockImplementation(path => {
-    if (path === `${fakeTestWorkingDirectory}/config`) {
-      return {
-        server: {
-          port: 1776
-        }
-      };
-    } else if (path === `${fakeTestWorkingDirectory}/node_modules/nodemon`) {
-      return MockNodemon;
-    }
-
-    throw new Error(`Unforeseen require call for ${path}`);
-  });
-
-  interpretAndExecuteCommand(["$", "Boring", "server", "--reload"]);
-
-  expect(MockNodemon.on).toHaveBeenCalledTimes(3);
-});
-
 test("tries to start maildev if default config", () => {
   const fakeTestWorkingDirectory = "/fake/directory/that/doesnt/exist";
 


### PR DESCRIPTION
This was causing issues inside of docker containers using supervisor by causing constant restarts. Pushes the nodemon etc concerns up to consumers and this just starts the server.

We can revisit this feature in the future.