### PR TITLE
bug: array length in new model files

### DIFF
--- a/src/cli/Command/GenerateModel.js
+++ b/src/cli/Command/GenerateModel.js
@@ -169,22 +169,25 @@ function createModel(rootDirectory, modelName, modelAttributes) {
     }
   });
 
-  const belongsToRelations =
-    belongsTo.length && buildBelongsToRelation(modelName, belongsTo);
+  const belongsToImports = belongsTo.length
+    ? belongsTo.reduce(
+        (acc, curr) => (acc += `const ${curr} = require('./${curr}')\n`),
+        ""
+      )
+    : "";
+  const belongsToRelations = belongsTo.length
+    ? buildBelongsToRelation(modelName, belongsTo)
+    : "";
 
   fs.writeFileSync(
     modelFile,
     `
     const Boring = require('@sodacitylabs/boring-framework');
     const ActiveRecord = Boring.Model.ActiveRecord;
-    ${(belongsTo.length &&
-      belongsTo.reduce(
-        (acc, curr) => (acc += `const ${curr} = require('./${curr}')\n`)
-      ),
-    "")}
+    ${belongsToImports}
 
     module.exports = class ${modelName} extends ActiveRecord {
-      ${belongsTo.length && belongsToRelations}
+      ${belongsToRelations}
     };
     `,
     "utf8"


### PR DESCRIPTION
---
name: Pull Request
about: Ask for code to be merged into master
---

**Describe your Code**
Prevents the array length from being injected into the model file

**Expected behavior**
new models dont have `0`; in them

**Related Issues**
closes #154 

**How to test**
Steps to test and verify the code works as expected:
1. generate a new folder in `links` using `node ../../` to target the branch code
2. generate a model
3. see that the model file does not have `0;` in it
